### PR TITLE
bugfix/duplicate-questions-front-end

### DIFF
--- a/src/components/admin/DetailedPublishedCheckIn.jsx
+++ b/src/components/admin/DetailedPublishedCheckIn.jsx
@@ -39,7 +39,7 @@ const DetailedPublishedCheckIn = () => {
   const location = useLocation();
   const { state } = location;
   const checkInName = state?.checkIn?.checkInId || '';
-  const responses = state?.checkIn?.responses || [];
+  const responses = state?.checkIn || []; // full check in object with responses and questions
   const toast = useToast();
   const [gridApi, setGridApi] = useState(null);
   const [filtersActive, setFiltersActive] = useState(false);
@@ -47,10 +47,18 @@ const DetailedPublishedCheckIn = () => {
   const transformData = (data) => {
     if (!data || data.length === 0) return { questions: [], answers: [] };
 
-    const questions = data[0].answers.map((answer) => answer.question);
-    const answers = data.map((item) => ({
+    // Get unique questions with their labels and IDs
+    const questions = data.questions.map((q) => ({
+      id: q.id,
+      label: q.label
+    }));
+
+    // Map answers using questionId as the field
+    const answers = data.responses.map((item) => ({
       fullName: `${item.submittedBy.firstName} ${item.submittedBy.lastName}`,
-      ...Object.fromEntries(item.answers.map((a) => [a.question, a.answer]))
+      ...Object.fromEntries(
+        item.answers.map((a) => [a.questionId.toString(), a.answer])
+      )
     }));
 
     return { questions, answers };
@@ -72,11 +80,11 @@ const DetailedPublishedCheckIn = () => {
 
     const questionColumns =
       questions?.map((question) => ({
-        headerName: question,
-        field: question,
+        headerName: question.label, // display question text
+        field: question.id.toString(), // use questionId as field, must match answer keys
         cellRenderer: TruncatedTextRenderer,
         filter: 'agTextColumnFilter',
-        headerTooltip: question
+        headerTooltip: question.label
       })) || [];
 
     return state.checkIn.anonymous

--- a/src/components/shared/FormFactory.jsx
+++ b/src/components/shared/FormFactory.jsx
@@ -26,7 +26,7 @@ const FormFactory = ({ onSubmit }) => {
   const checkInId = publishedCheckIn?.checkInId;
   const initialValues = publishedCheckIn?.questions?.reduce(
     (values, question) => {
-      values[question.label] = '';
+      values[question.id] = '';
       return values;
     },
     {}
@@ -34,8 +34,9 @@ const FormFactory = ({ onSubmit }) => {
 
   const handleSubmit = (values) => {
     // Transform the values into an array format
-    const answers = Object.entries(values).map(([question, answer]) => ({
-      question,
+    const answers = Object.entries(values).map(([questionId, answer]) => ({
+      questionId,
+      question: publishedCheckIn?.questions[questionId].label,
       answer
     }));
 
@@ -52,11 +53,11 @@ const FormFactory = ({ onSubmit }) => {
 
     questions?.forEach((question) => {
       if (question.isRequired) {
-        schemaShape[question.label] = Yup.string().required(
+        schemaShape[question.id] = Yup.string().required(
           'This field is required'
         );
       } else {
-        schemaShape[question.label] = Yup.string();
+        schemaShape[question.id] = Yup.string();
       }
     });
     return Yup.object().shape(schemaShape);
@@ -112,14 +113,14 @@ const FormFactory = ({ onSubmit }) => {
       >
         {({ values, setFieldValue, isValid }) => (
           <Form>
-            {publishedCheckIn?.questions?.map((question, index) => (
-              <Field key={index} name={question.label}>
+            {publishedCheckIn?.questions?.map((question) => (
+              <Field key={question.id} name={question.id}>
                 {({ field, form }) => (
                   <FormControl
                     isRequired={question.isRequired}
                     isInvalid={
-                      form.errors[question.label] &&
-                      form.touched[question.label]
+                      form.errors[question.id] &&
+                      form.touched[question.id]
                     }
                     mb="1rem"
                   >
@@ -149,9 +150,9 @@ const FormFactory = ({ onSubmit }) => {
                     {question.componentType === 'radio' && (
                       <RadioGroup
                         {...field}
-                        value={values[question.label]}
+                        value={values[question.id]}
                         onChange={(value) =>
-                          setFieldValue(question.label, value)
+                          setFieldValue(question.id, value)
                         }
                       >
                         <Stack direction="row">
@@ -164,7 +165,7 @@ const FormFactory = ({ onSubmit }) => {
                       </RadioGroup>
                     )}
                     <FormErrorMessage>
-                      {form.errors[question.label]}
+                      {form.errors[question.id]}
                     </FormErrorMessage>
                   </FormControl>
                 )}

--- a/src/components/user/ViewSubmittedCheckInModal.jsx
+++ b/src/components/user/ViewSubmittedCheckInModal.jsx
@@ -32,7 +32,7 @@ const ViewSubmittedCheckInModal = () => {
     (question) => {
       // Find matching answer for this question label
       const matchingAnswer = userViewSubmittedCheckIn?.data?.answers?.find(
-        (answer) => answer.question === question.label
+        (answer) => answer.questionId === question.id
       );
 
       return {

--- a/src/store/checkin-store.js
+++ b/src/store/checkin-store.js
@@ -168,6 +168,7 @@ const useCheckInStore = create((set) => ({
     set(
       produce((state) => {
         state.questions = [];
+        state.nextQuestionId = 0;
       })
     ),
   resetAdminAction: () =>


### PR DESCRIPTION
This PR contains the following
* Fix code where duplicate questions were asked and answer being submitted was using the first question
* Adjust code when user is viewing their submitted check in, the correct answers are shown in case of duplicates
* Adjust code when admin is viewing the user submitted check in inside AG-GRID, the correct answers are shown in the grid
* Fix minor bug where nextQuestionId was not being resetted after a check in is created