### PR TITLE
Feature/add duplicate check in functionality

### DIFF
--- a/src/components/admin/CreatedCheckInCard.jsx
+++ b/src/components/admin/CreatedCheckInCard.jsx
@@ -6,7 +6,11 @@ import {
   Flex,
   IconButton,
   Text,
-  Badge
+  Badge,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem
 } from '@chakra-ui/react';
 import {
   MdDeleteOutline,
@@ -14,7 +18,9 @@ import {
   MdUnpublished,
   MdPublish,
   MdOutlineQuestionAnswer,
-  MdOutlineRemoveRedEye
+  MdOutlineRemoveRedEye,
+  MdControlPointDuplicate,
+  MdMoreVert
 } from 'react-icons/md';
 import useCheckInStore from '../../store/checkin-store';
 import { useState } from 'react';
@@ -28,6 +34,10 @@ const CreatedCheckInCard = ({
   const [isProcessing, setIsProcessing] = useState(false);
   const setAdminAction = useCheckInStore((state) => state.setAdminAction);
   const adminAction = useCheckInStore((state) => state.adminAction);
+  const setToggleDuplicateModal = useCheckInStore(
+    (state) => state.setToggleDuplicateModal
+  );
+
   const navigate = useNavigate();
 
   const setSubmittedCheckInToEdit = useCheckInStore(
@@ -105,26 +115,47 @@ const CreatedCheckInCard = ({
           >
             {availableCheckIn.checkInId}
           </Text>
+        </Flex>
+
+        <Flex position="absolute" right="0" top="0" align="center" gap={2}>
           <Badge
             colorScheme={isCurrentlyPublished ? 'green' : 'gray'}
             variant="subtle"
-            position="absolute"
-            right="0"
-            top="0"
             fontSize="xs"
           >
             {isCurrentlyPublished ? 'Active' : 'Draft'}
           </Badge>
+          <Menu>
+            <MenuButton
+              as={IconButton}
+              aria-label="Options"
+              icon={<MdMoreVert />}
+              variant="ghost"
+              size="sm"
+            />
+            <MenuList>
+              <MenuItem
+                icon={<MdControlPointDuplicate />}
+                onClick={() => setToggleDuplicateModal(availableCheckIn)}
+              >
+                Duplicate
+              </MenuItem>
+            </MenuList>
+          </Menu>
         </Flex>
       </Box>
-
       {/* Metadata */}
       <Box mt={2} mb={4}>
         <Text fontSize="sm" color="gray.500" noOfLines={2}>
           Created by {availableCheckIn.createdBy}
         </Text>
         {availableCheckIn.anonymous && (
-          <Text fontSize="sm" color="gray.500" noOfLines={2} fontStyle={'italic'} >
+          <Text
+            fontSize="sm"
+            color="gray.500"
+            noOfLines={2}
+            fontStyle={'italic'}
+          >
             This Check-in is anonymous
           </Text>
         )}

--- a/src/components/checkinBuilder/CheckInSubmitter.jsx
+++ b/src/components/checkinBuilder/CheckInSubmitter.jsx
@@ -11,43 +11,24 @@ import {
   Icon,
   Box
 } from '@chakra-ui/react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import useAdminService from '../../hooks/services/useAdminService';
 import { useRef, useState } from 'react';
 import { useLocalAuth } from '../../context/LocalAuthProvider';
 import { MdPublish, MdHelpOutline } from 'react-icons/md';
 import useCheckInStore from '../../store/checkin-store';
+import { useCreateCheckIn } from '../../hooks/useCreateCheckIn';
 
 export const CheckInSubmitter = () => {
   const questions = useCheckInStore((state) => state.questions);
   const resetQuestions = useCheckInStore((state) => state.resetQuestions);
 
   const { userDetails } = useLocalAuth();
-  const { createAdminCheckIn } = useAdminService();
-  const queryClient = useQueryClient();
   const toast = useToast();
   const checkInNameRef = useRef();
   const [isCheckInAnonymous, setIsCheckInAnonymous] = useState(false);
 
-  const { mutate: saveCheckIn, isPending } = useMutation({
-    mutationFn: createAdminCheckIn,
-    onSuccess: () => {
-      toast({
-        title: 'Check-in Created!',
-        status: 'success',
-        duration: 3000
-      });
-      queryClient.refetchQueries(['allAdminCheckIn']);
-      resetQuestions();
-    },
-    onError: (error) => {
-      toast({
-        title: 'Error Creating Check-in',
-        description: error.response?.data?.message,
-        status: 'error',
-        duration: 3000
-      });
-    }
+  const { mutate: saveCheckIn, isPending} = useCreateCheckIn({
+    refetchQueryKeys: [['allAdminCheckIn']],
+    afterSuccess: resetQuestions
   });
 
   const handleSaveCheckIn = () => {

--- a/src/components/shared/DuplicatePopUpModal.jsx
+++ b/src/components/shared/DuplicatePopUpModal.jsx
@@ -1,0 +1,84 @@
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalOverlay,
+  ModalHeader
+} from '@chakra-ui/react';
+import useCheckInStore from '../../store/checkin-store';
+import { useState } from 'react';
+import { useCreateCheckIn } from '../../hooks/useCreateCheckIn';
+const DuplicatePopUpModal = () => {
+  const [duplicateCheckInName, setDuplicateCheckInName] = useState('');
+
+  const closeDuplicateModal = useCheckInStore(
+    (state) => state.closeDuplicateModal
+  );
+
+  const duplicateCheckInData = useCheckInStore(
+    (state) => state.duplicateCheckInData
+  );
+  const toggleDuplicateModal = useCheckInStore(
+    (state) => state.toggleDuplicateModal
+  );
+
+  const { mutate: saveCheckIn, isPending } = useCreateCheckIn({
+    refetchQueryKeys: [['allAdminCheckIn']],
+    afterSuccess: closeDuplicateModal,
+    afterError: closeDuplicateModal
+  });
+
+  const handleCreate = () => {
+    const payload = {
+      ...duplicateCheckInData,
+      checkInId: duplicateCheckInName
+    };
+    saveCheckIn(payload);
+  };
+
+  const handleOnClose = () => {
+    setDuplicateCheckInName('');
+    closeDuplicateModal();
+  };
+
+  return (
+    <>
+      <Modal isOpen={toggleDuplicateModal} onClose={handleOnClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Duplicating your check-in</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody pb={6}>
+            <FormControl>
+              <FormLabel>Check-in name</FormLabel>
+              <Input
+                onChange={(e) => setDuplicateCheckInName(e.target.value)}
+              />
+            </FormControl>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button
+              colorScheme="orange"
+              mr={3}
+              onClick={handleCreate}
+              isDisabled={!duplicateCheckInName}
+              isLoading={isPending}
+              loadingText={'Creating...'}
+            >
+              Create
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default DuplicatePopUpModal;

--- a/src/components/shared/ProtectedComponents.jsx
+++ b/src/components/shared/ProtectedComponents.jsx
@@ -4,6 +4,7 @@ import EditCheckInModal from '../admin/EditCheckInModal';
 import CaptureUserDetails from '../shared/CaptureUserDetails';
 import ViewSubmittedCheckInModal from '../user/ViewSubmittedCheckInModal';
 import PopUpModal from './PopUpModal';
+import DuplicatePopUpModal from './DuplicatePopUpModal';
 
 const ProtectedComponents = () => {
   const { isAuthenticated, isLoading } = useAuth0();
@@ -17,6 +18,7 @@ const ProtectedComponents = () => {
       <CaptureUserDetails />
       <PopUpModal />
       <ViewSubmittedCheckInModal />
+      <DuplicatePopUpModal />
     </>
   );
 };

--- a/src/hooks/useAxiosClient.jsx
+++ b/src/hooks/useAxiosClient.jsx
@@ -33,7 +33,6 @@ const useAxiosClient = () => {
       
       // Use cached token if valid
       if (cachedToken && cachedTokenExpiry && cachedTokenExpiry > now + 60) {
-        console.log('Using cached token');
         config.headers.Authorization = `Bearer ${cachedToken}`;
         if (cachedUserSub) {
           config.headers['X-User-Id'] = cachedUserSub;

--- a/src/hooks/useCreateCheckIn.jsx
+++ b/src/hooks/useCreateCheckIn.jsx
@@ -1,0 +1,55 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useToast } from '@chakra-ui/react';
+import useAdminService from './services/useAdminService';
+
+export const useCreateCheckIn = (options = {}) => {
+  const {
+    afterSuccess,
+    afterError,
+    onSuccessMessage = 'Check-in Created!',
+    onErrorMessage = 'Error Creating Check-in',
+    customSuccessToast,
+    customErrorToast,
+    refetchQueryKeys = [['allAdminCheckIn']]
+  } = options;
+
+  const { createAdminCheckIn } = useAdminService();
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  return useMutation({
+    mutationFn: createAdminCheckIn,
+    onSuccess: () => {
+      if (customSuccessToast) {
+        toast(customSuccessToast());
+      } else {
+        toast({
+          title: onSuccessMessage,
+          status: 'success',
+          duration: 3000,
+          isClosable: true
+        });
+      }
+
+      refetchQueryKeys.forEach((key) => queryClient.refetchQueries(key));
+
+      if (afterSuccess) afterSuccess();
+    },
+    onError: (error) => {
+      if (customErrorToast) {
+        toast(customErrorToast());
+      } else {
+        toast({
+          title: onErrorMessage,
+          description:
+            error?.response?.data?.message || 'An unexpected error occurred',
+          status: 'error',
+          duration: 3000,
+          isClosable: true
+        });
+      }
+
+      if (afterError) afterError();
+    }
+  });
+};

--- a/src/store/checkin-store.js
+++ b/src/store/checkin-store.js
@@ -115,7 +115,6 @@ const useCheckInStore = create((set) => ({
   setToggleDuplicateModal: (checkInToDuplicate) =>
     set(
       produce((state) => {
-        console.log('check in to duplicate', checkInToDuplicate);
         state.toggleDuplicateModal = !state.toggleDuplicateModal;
         state.duplicateCheckInData = {
           createdBy: checkInToDuplicate.createdBy,

--- a/src/store/checkin-store.js
+++ b/src/store/checkin-store.js
@@ -9,6 +9,8 @@ const useCheckInStore = create((set) => ({
   toggleModal: false,
   toggleEditModal: false,
   toggleDeleteModal: false,
+  toggleDuplicateModal: false,
+  duplicateCheckInData: null,
   deleteModalConfig: {
     id: null,
     header: '',
@@ -110,6 +112,19 @@ const useCheckInStore = create((set) => ({
           !state.toggleUserViewSubmittedCheckInModal;
       })
     ),
+  setToggleDuplicateModal: (checkInToDuplicate) =>
+    set(
+      produce((state) => {
+        console.log('check in to duplicate', checkInToDuplicate);
+        state.toggleDuplicateModal = !state.toggleDuplicateModal;
+        state.duplicateCheckInData = {
+          createdBy: checkInToDuplicate.createdBy,
+          published: false,
+          questions: checkInToDuplicate.questions,
+          anonymous: checkInToDuplicate.anonymous
+        };
+      })
+    ),
   setToggleEditModal: () =>
     set((state) => ({ toggleEditModal: !state.toggleEditModal })),
   openDeleteModal: (config) =>
@@ -134,6 +149,14 @@ const useCheckInStore = create((set) => ({
           body: '',
           onConfirm: null
         };
+      })
+    ),
+
+  closeDuplicateModal: () =>
+    set(
+      produce((state) => {
+        state.toggleDuplicateModal = !state.toggleDuplicateModal;
+        state.duplicateCheckInData = null;
       })
     ),
   addQuestion: (question) =>


### PR DESCRIPTION
This PR contains
* New zustand state to hold data for duplicating check in
* Duplicate check in modal
* Create re-usable custom hook (useCreateCheckIn) to be used in duplicate modal
* Add new UI Menu to each created check in card to allow admin to duplicate the check in
* Re-use new custom hook in check in submitter